### PR TITLE
Properly add default console transport if no transports are configured

### DIFF
--- a/tasks/winston.js
+++ b/tasks/winston.js
@@ -15,7 +15,7 @@ module.exports = function(grunt) {
 
         var logger = new winston.Logger(config);
         if (!transports) {
-            transports = [new winston.transports.Console()];
+            logger.add(winston.transports.Console);
         } else {
             _.each(transports, function(options, type) {
                 if ('undefined' === winston.transports[type]) {


### PR DESCRIPTION
I wasn't adding the default console transport to the logger.
